### PR TITLE
Update public shell dotfiles

### DIFF
--- a/.bash_aliases
+++ b/.bash_aliases
@@ -9,7 +9,7 @@ if command -v lsd &> /dev/null; then
     if [ "$TERM" != "linux" ]; then
         alias ls='lsd --group-directories-first'
     else
-        alias ls='lsd --group-directories-first --icon never'
+        alias ls='lsd --group-directories-first --icon never --ignore-config'
     fi
 fi
 
@@ -29,7 +29,7 @@ alias mount='mount |column -t'
 alias h='history'
 alias j='jobs -l'
 alias path='echo -e ${PATH//:/\\n}'
-alias now='date +"%T'
+alias now='date +"%T"'
 alias nowtime=now
 alias nowdate='date +"%d-%m-%Y"'
 alias ping='ping -c 5'
@@ -57,7 +57,7 @@ alias music='ncmpc'
 alias musicpp='ncmpcpp'
 alias gs='git status'
 alias gd='git diff'
-alias cat='batcat --theme Dracula'
+! hash batcat 2>/dev/null || alias cat='batcat --theme Dracula'
 alias fd='fdfind'
 alias cool='$HOME'/.local/bin/cool
 alias yt="yt-dlp --embed-metadata -i"
@@ -73,3 +73,5 @@ alias tree="ls --tree"
 alias lt="ls --tree"
 alias cryptmount="gocryptfs -config ~/.config/gocryptfs/crypt.conf ~/.Privat ~/Privat"
 alias cryptunmount="fusermount -u ~/Privat"
+# https://www.atlassian.com/git/tutorials/dotfiles
+alias config='/usr/bin/git --git-dir=$HOME/.dotfiles/ --work-tree=$HOME'

--- a/.bashrc
+++ b/.bashrc
@@ -9,16 +9,16 @@
 # If not running interactively, don't do anything
 [[ $- != *i* ]] && return
 
-# no duplicate entries, ignore lines begin with space
-HISTCONTROL=ignoredups:erasedups:ignorespace
+# remove duplicate entries, ignore lines beginning with a space
+HISTCONTROL=erasedups:ignorespace
 
 ### SHOPT
-shopt -s histappend     # do not overwrite history
-shopt -s checkwinsize   # checks term size when bash regains control
-shopt -s cmdhist        # save multi-line commands in history as single line
-shopt -s cdspell        # autocorrects cd misspellings
+shopt -s histappend   # do not overwrite history
+shopt -s checkwinsize # checks term size when bash regains control
+shopt -s cmdhist      # save multi-line commands in history as single line
+shopt -s cdspell      # autocorrects cd misspellings
 
-set -o vi               # use vi keybindings instead of emacs keybindings (readline)
+set -o vi # use vi keybindings instead of emacs keybindings (readline)
 
 bind "set colored-completion-prefix on"
 bind "set colored-stats on"
@@ -27,8 +27,8 @@ bind "set completion-ignore-case on" # enable case-insensitive tab completion
 # ctrl-l has been missed since vi instead emacs keybindings are used
 bind -m vi-insert "\C-l":clear-screen
 
-# enabling search forward (ctrl-s)
-stty -ixon
+# enabling search forward (ctrl-s) when stdin is a terminal
+[[ -t 0 ]] && stty -ixon
 
 # for setting history length see HISTSIZE and HISTFILESIZE in bash(1)
 HISTSIZE=20000
@@ -45,25 +45,11 @@ if [ -z "${debian_chroot:-}" ] && [ -r /etc/debian_chroot ]; then
     debian_chroot=$(cat /etc/debian_chroot)
 fi
 
-# set a fancy prompt (non-color, unless we know we "want" color)
-case "$TERM" in
-    xterm-color) color_prompt=yes;;
-esac
-
-# uncomment for a colored prompt, if the terminal has the capability; turned
-# off by default to not distract the user: the focus in a terminal window
-# should be on the output of commands, not on the prompt
-force_color_prompt=yes
-
-if [ -n "$force_color_prompt" ]; then
-    if [ -x /usr/bin/tput ] && tput setaf 1 >&/dev/null; then
-    # We have color support; assume it's compliant with Ecma-48
-    # (ISO/IEC-6429). (Lack of such support is extremely rare, and such
-    # a case would tend to support setf rather than setaf.)
-        color_prompt=yes
-    else
-        color_prompt=
-    fi
+# use a colored prompt when the terminal supports it
+if [ -x /usr/bin/tput ] && tput setaf 1 >&/dev/null; then
+    color_prompt=yes
+else
+    color_prompt=
 fi
 
 if [ "$color_prompt" = yes ]; then
@@ -71,20 +57,31 @@ if [ "$color_prompt" = yes ]; then
 else
     PS1='${debian_chroot:+($debian_chroot)}\u@\h:\w\$ '
 fi
-unset color_prompt force_color_prompt
+unset color_prompt
 
 # If this is an xterm set the title to user@host:dir
 case "$TERM" in
-xterm*|rxvt*)
+xterm* | rxvt*)
     PS1="\[\e]0;${debian_chroot:+($debian_chroot)}\u@\h: \w\a\]$PS1"
     ;;
-*)
-    ;;
+*) ;;
 esac
 
 # enable color support of ls and also add handy aliases
-if [ -x /usr/bin/dircolors ]; then
-    test -r "$HOME/.dircolors" && eval "$(dircolors -b "$HOME/.dircolors")" || eval "$(dircolors -b)"
+if command -v dircolors >/dev/null 2>&1; then
+    if [ "$TERM" = "linux" ]; then
+        if test -r "$HOME/.dircolors_tty"; then
+            eval "$(dircolors -b "$HOME/.dircolors_tty")"
+        else
+            eval "$(dircolors -b)"
+        fi
+    else
+        if test -r "$HOME/.dircolors"; then
+            eval "$(dircolors -b "$HOME/.dircolors")"
+        else
+            eval "$(dircolors -b)"
+        fi
+    fi
     alias ls='ls --color=auto'
 fi
 
@@ -109,68 +106,84 @@ fi
 
 # https://wiki.ubuntuusers.de/Paketverwaltung/Tipps/
 apt-history() {
-      case "$1" in
-        install)
-              cat /var/log/{dpkg.log,dpkg.log.1} | grep 'install '
-              ;;
-        upgrade|remove)
-              cat /var/log/{dpkg.log,dpkg.log.1} | grep "$1"
-              ;;
-        rollback)
-              cat /var/log/{dpkg.log,dpkg.log.1} | grep upgrade | \
-                  grep "$2" -A10000000 | \
-                  grep "$3" -B10000000 | \
-                  awk '{print $4"="$5}'
-              ;;
-        *)
-              cat /var/log/{dpkg.log,dpkg.log.1}
-              ;;
-      esac
+    local action=${1:-}
+    local log
+    local -a logs=()
+
+    for log in /var/log/dpkg.log /var/log/dpkg.log.1 /var/log/dpkg.log.*.gz; do
+        [[ -r $log ]] && logs+=("$log")
+    done
+
+    if ((${#logs[@]} == 0)); then
+        printf 'apt-history: keine lesbaren dpkg-Protokolle gefunden\n' >&2
+        return 1
+    fi
+
+    case "$action" in
+    install)
+        zgrep -hF -- ' install ' "${logs[@]}"
+        ;;
+    upgrade | remove)
+        zgrep -hF -- " $action " "${logs[@]}"
+        ;;
+    rollback)
+        if (($# != 3)); then
+            printf 'Verwendung: apt-history rollback START ENDE\n' >&2
+            return 2
+        fi
+        zgrep -hF -- ' upgrade ' "${logs[@]}" |
+            grep -F -A10000000 -- "$2" |
+            grep -F -B10000000 -- "$3" |
+            awk '{print $4"="$5}'
+        ;;
+    *)
+        zcat -f -- "${logs[@]}"
+        ;;
+    esac
 }
 
 # https://linupedia.org/opensuse/Farbe_in_der_Konsole
 # Farbiger Errorlevel im Prompt
 prompt_command() {
-    LASTERROR="[$?]"
-    if [[ ${LASTERROR} != "[0]" ]]; then
-        echo -ne "\033[93;41m${LASTERROR}\033[0m"
+    local exit_status=${STARSHIP_CMD_STATUS:-$?}
+
+    if ((exit_status != 0)); then
+        printf '\033[93;41m[%d]\033[0m' "$exit_status"
     fi
 }
 
-PROMPT_COMMAND=prompt_command
-
 ### PATH
-if [ -d "$HOME/.bin" ] ; then
-    PATH="$HOME/.bin:$PATH"
-fi
+path_prepend() {
+    [[ -d $1 ]] || return 0
+    case ":$PATH:" in
+    *":$1:"*) ;;
+    *) PATH="$1${PATH:+:$PATH}" ;;
+    esac
+}
 
-if [ -d "$HOME/.local/bin" ] ; then
-    PATH="$HOME/.local/bin:$PATH"
-fi
+path_prepend "$HOME/.bin"
+path_prepend "$HOME/.local/bin"
+path_prepend "$HOME/.cargo/bin"
+export PATH
+unset -f path_prepend
 
-if [ -d "$HOME/.cargo/bin" ] ; then
-    PATH="$HOME/.cargo/bin:$PATH"
-fi
-
-### SETTING THE STARSHIP PROMPT ###
-if command -v starship &> /dev/null; then
-        eval "$(starship init bash)"
-fi
-
-export EDITOR="/usr/bin/vim"
-export TERMINAL="/usr/bin/alacritty"
-export BROWSER="/usr/bin/brave-browser"
-export READER="/usr/bin/zathura"
+export EDITOR="vim"
+export TERMINAL="alacritty"
+export BROWSER="brave-browser"
+export READER="zathura"
 export OPENER="xdg-open" # needed by lf
 
 # https://wiki.archlinux.org/title/HiDPI
 #export QT_AUTO_SCREEN_SCALE_FACTOR=1
 #export QT_QPA_PLATFORMTHEME="gtk2" # Have QT use gtk2 theme.
 
+# for better compatibility
+export MANROFFOPT="-c"
 ### "bat" as manpager
-#export MANPAGER="sh -c 'col -bx | batcat -l man -p'"
-### "vim" as manpager
-if [ "$(command -v vim)" ]; then
+if command -v batcat >/dev/null 2>&1; then
+    export MANPAGER="sh -c 'col -bx | batcat -l man -p'"
+elif command -v vim >/dev/null 2>&1; then
+    ### "vim" as manpager
     export MANPAGER="/bin/sh -c \"col -b | vim -c 'set ft=man ts=8 nomod nolist nonu noma|:IndentLinesDisable' -\""
 fi
 
@@ -184,14 +197,33 @@ if [ -f "$LFCD" ]; then
 fi
 
 # fasd - quick access to files and directories, see https://github.com/clvv/fasd/tree/master
-if [ "$(command -v fasd)" ]; then
+if fasd_path=$(command -v fasd 2>/dev/null); then
     fasd_cache="$HOME/.fasd-init-bash"
-    if [ "$(command -v fasd)" -nt "$fasd_cache" ] || [ ! -s "$fasd_cache" ]; then
-        fasd --init posix-alias bash-hook bash-ccomp bash-ccomp-install >| "$fasd_cache"
+    if [ "$fasd_path" -nt "$fasd_cache" ] || [ ! -s "$fasd_cache" ]; then
+        fasd --init posix-alias bash-hook bash-ccomp bash-ccomp-install >|"$fasd_cache"
     fi
-    # shellcheck source=.fasd-init-bash
-    source "$fasd_cache"
+    if ! declare -F _fasd_prompt_func >/dev/null; then
+        # shellcheck source=.fasd-init-bash
+        source "$fasd_cache"
+    fi
     unset fasd_cache
+fi
+unset fasd_path
+
+### SETTING THE STARSHIP PROMPT ###
+# Initialize Starship after fasd so it can preserve fasd's prompt hook and
+# capture the command's real exit status before fasd runs.
+if command -v starship >/dev/null 2>&1; then
+    if ! declare -F starship_precmd >/dev/null; then
+        eval "$(starship init bash)"
+    fi
+    # shellcheck disable=SC2034 # Read dynamically by starship_precmd.
+    starship_precmd_user_func=prompt_command
+else
+    case ";${PROMPT_COMMAND:-};" in
+    *';prompt_command;'*) ;;
+    *) PROMPT_COMMAND="prompt_command${PROMPT_COMMAND:+;$PROMPT_COMMAND}" ;;
+    esac
 fi
 
 # https://github.com/Canop/broot
@@ -210,3 +242,27 @@ fi
 if [ -f "$HOME/.config/bash/fzf.bash" ]; then
     source "$HOME/.config/bash/fzf.bash"
 fi
+
+# terminal command 'open' shall use glow for markdown-files
+# solution via mime is not perfect as another terminal window
+# is opened
+open() {
+    if (($# != 1)); then
+        printf 'Verwendung: open DATEI_ODER_URL\n' >&2
+        return 2
+    fi
+
+    case "${1,,}" in
+    *.md | *.markdown)
+        if command -v glow >/dev/null 2>&1; then
+            command glow -p -- "$1"
+        else
+            printf 'open: glow ist nicht installiert; verwende xdg-open\n' >&2
+            command xdg-open "$@"
+        fi
+        ;;
+    *)
+        command xdg-open "$@"
+        ;;
+    esac
+}

--- a/.dircolors
+++ b/.dircolors
@@ -1,6 +1,51 @@
-# Term Section
-TERM Eterm
+# Exact Solarized color theme for the color GNU ls utility.
+# Designed for dircolors (GNU coreutils) 5.97
+#
+# This simple theme was simultaneously designed for these terminal color schemes:
+# - Solarized dark  (best)
+# - Solarized light (best)
+# - default dark
+# - default light
+#
+# How the colors were selected:
+# - Terminal emulators often have an option typically enabled by default that makes
+#   bold a different color.  It is important to leave this option enabled so that
+#   you can access the entire 16-color Solarized palette, and not just 8 colors.
+# - We favor universality over a greater number of colors.  So we limit the number
+#   of colors so that this theme will work out of the box in all terminals,
+#   Solarized or not, dark or light.
+# - We choose to have the following category of files:
+#   NORMAL & FILE, DIR, LINK, EXEC and
+#   editable text including source, unimportant text, binary docs & multimedia source
+#   files, viewable multimedia, archived/compressed, and unimportant non-text
+# - For uniqueness, we stay away from the Solarized foreground colors are -- either
+#   base00 (brightyellow) or base0 (brightblue).  However, they can be used if
+#   you know what the bg/fg colors of your terminal are, in order to optimize the display.
+# - 3 different options are provided: universal, solarized dark, and solarized light.
+#   The only difference between the universal scheme and one that's optimized for
+#   dark/light is the color of "unimportant" files, which should blend more with the
+#   background
+# - We note that blue is the hardest color to see on dark bg and yellow is the hardest
+#   color to see on light bg (with blue being particularly bad).  So we choose yellow
+#   for multimedia files which are usually accessed in a GUI folder browser anyway.
+#   And blue is kept for custom use of this scheme's user.
+# - See table below to see the assignments.
+
+
+# Installation instructions:
+# This file goes in the /etc directory, and must be world readable.
+# You can copy this file to .dir_colors in your $HOME directory to override
+# the system defaults.
+
+# COLOR needs one of these arguments: 'tty' colorizes output to ttys, but not
+# pipes. 'all' adds color characters to all output. 'none' shuts colorization
+# off.
+COLOR tty
+
+# Below, there should be one TERM entry for each termtype that is colorizable
+TERM alacritty
 TERM ansi
+TERM color_xterm
 TERM color-xterm
 TERM con132x25
 TERM con132x30
@@ -18,6 +63,7 @@ TERM cygwin
 TERM dtterm
 TERM dvtm
 TERM dvtm-256color
+TERM Eterm
 TERM eterm-color
 TERM fbterm
 TERM gnome
@@ -30,6 +76,7 @@ TERM linux
 TERM linux-c
 TERM mach-color
 TERM mlterm
+TERM nxterm
 TERM putty
 TERM putty-256color
 TERM rxvt
@@ -51,8 +98,9 @@ TERM screen-256color-bce-s
 TERM screen-256color-italic
 TERM screen-bce
 TERM screen-w
-TERM screen.linux
 TERM screen.xterm-256color
+TERM screen.linux
+TERM screen.xterm-new
 TERM st
 TERM st-meta
 TERM st-256color
@@ -61,233 +109,377 @@ TERM tmux
 TERM tmux-256color
 TERM vt100
 TERM xterm
+TERM xterm-new
 TERM xterm-16color
 TERM xterm-256color
 TERM xterm-256color-italic
 TERM xterm-88color
 TERM xterm-color
 TERM xterm-debian
+TERM xterm-kitty
 TERM xterm-termite
 
-## Documentation
-#
-# standard colors
-#
+# EIGHTBIT, followed by '1' for on, '0' for off. (8-bit output)
+EIGHTBIT 1
+
+#############################################################################
 # Below are the color init strings for the basic file types. A color init
 # string consists of one or more of the following numeric codes:
+#
 # Attribute codes:
-# 00=none 01=bold 04=underscore 05=blink 07=reverse 08=concealed
+#   00=none 01=bold 04=underscore 05=blink 07=reverse 08=concealed
 # Text color codes:
-# 30=black 31=red 32=green 33=yellow 34=blue 35=magenta 36=cyan 37=white
+#   30=black 31=red 32=green 33=yellow 34=blue 35=magenta 36=cyan 37=white
 # Background color codes:
-# 40=black 41=red 42=green 43=yellow 44=blue 45=magenta 46=cyan 47=white
+#   40=black 41=red 42=green 43=yellow 44=blue 45=magenta 46=cyan 47=white
 #
-#
-# 256 color support
-# see here: http://www.mail-archive.com/bug-coreutils@gnu.org/msg11030.html)
-#
-# Text 256 color coding:
-# 38;5;COLOR_NUMBER
-# Background 256 color coding:
-# 48;5;COLOR_NUMBER
-
-## Special files
-
-NORMAL 00;38;5;15 # no color code at all
-#FILE 00 # regular file: use no color at all
-RESET 0 # reset to "normal" color
-DIR 00;38;5;6 # directory 01;34
-LINK 00;38;5;2 # symbolic link. (If you set this to 'target' instead of a
- # numerical value, the color is as for the file pointed to.)
-MULTIHARDLINK 00 # regular file with more than one link
-FIFO 48;5;0;38;5;3;01 # pipe
-SOCK 48;5;0;38;5;3;01 # socket
-DOOR 48;5;0;38;5;3;01 # door
-BLK 48;5;0;38;5;15;01 # block device driver
-CHR 48;5;0;38;5;15;01 # character device driver
-ORPHAN 48;5;0;38;5;1 # symlink to nonexistent file, or non-stat'able file
-SETUID 48;5;1;38;5;3 # file that is setuid (u+s)
-SETGID 48;5;1;38;5;3 # file that is setgid (g+s)
-CAPABILITY 30;41 # file with capability
-STICKY_OTHER_WRITABLE 48;5;2;38;5;3 # dir that is sticky and other-writable (+t,o+w)
-OTHER_WRITABLE 48;5;0;38;5;6 # dir that is other-writable (o+w) and not sticky
-STICKY 48;5;6;38;5;3 # dir with the sticky bit set (+t) and not other-writable
-# This is for files with execute permission:
-EXEC 00;38;5;2
-
-## Archives or compressed (violet + bold for compression)
-.tar    00;38;5;4
-.tgz    00;38;5;4
-.arj    00;38;5;4
-.taz    00;38;5;4
-.lzh    00;38;5;4
-.lzma   00;38;5;4
-.tlz    00;38;5;4
-.txz    00;38;5;4
-.zip    00;38;5;4
-.z      00;38;5;4
-.Z      00;38;5;4
-.dz     00;38;5;4
-.gz     00;38;5;4
-.lz     00;38;5;4
-.xz     00;38;5;4
-.bz2    00;38;5;4
-.bz     00;38;5;4
-.tbz    00;38;5;4
-.tbz2   00;38;5;4
-.tz     00;38;5;4
-.deb    00;38;5;4
-.rpm    00;38;5;4
-.jar    00;38;5;4
-.rar    00;38;5;4
-.ace    00;38;5;4
-.zoo    00;38;5;4
-.cpio   00;38;5;4
-.7z     00;38;5;4
-.rz     00;38;5;4
-.apk    00;38;5;4
-.gem    00;38;5;4
-
-# Image formats (yellow)
-.jpg    00;38;5;3
-.JPG    00;38;5;3 #stupid but needed
-.jpeg   00;38;5;3
-.gif    00;38;5;3
-.bmp    00;38;5;3
-.pbm    00;38;5;3
-.pgm    00;38;5;3
-.ppm    00;38;5;3
-.tga    00;38;5;3
-.xbm    00;38;5;3
-.xpm    00;38;5;3
-.tif    00;38;5;3
-.tiff   00;38;5;3
-.png    00;38;5;3
-.PNG    00;38;5;3
-.svg    00;38;5;3
-.svgz   00;38;5;3
-.mng    00;38;5;3
-.pcx    00;38;5;3
-.dl     00;38;5;3
-.xcf    00;38;5;3
-.xwd    00;38;5;3
-.yuv    00;38;5;3
-.cgm    00;38;5;3
-.emf    00;38;5;3
-.eps    00;38;5;3
-.CR2    00;38;5;3
-.ico    00;38;5;3
-
-# Files of special interest (base1)
-.tex             00;38;5;7
-.rdf             00;38;5;7
-.owl             00;38;5;7
-.n3              00;38;5;7
-.ttl             00;38;5;7
-.nt              00;38;5;7
-.torrent         00;38;5;7
-.xml             00;38;5;7
-*Makefile        00;38;5;7
-*Rakefile        00;38;5;7
-*Dockerfile      00;38;5;7
-*build.xml       00;38;5;7
-*rc              00;38;5;7
-*1               00;38;5;7
-.nfo             00;38;5;7
-*README          00;38;5;7
-*README.txt      00;38;5;7
-*readme.txt      00;38;5;7
-.md              00;38;5;7
-*README.markdown 00;38;5;7
-.ini             00;38;5;7
-.yml             00;38;5;7
-.cfg             00;38;5;7
-.conf            00;38;5;7
-.h               00;38;5;7
-.hpp             00;38;5;7
-.c               00;38;5;7
-.cpp             00;38;5;7
-.cxx             00;38;5;7
-.cc              00;38;5;7
-.objc            00;38;5;7
-.sqlite          00;38;5;7
-.go              00;38;5;7
-.sql             00;38;5;7
-.csv             00;38;5;7
-
-# "unimportant" files as logs and backups (base01)
-.log        00;38;5;8
-.bak        00;38;5;8
-.aux        00;38;5;8
-.lof        00;38;5;8
-.lol        00;38;5;8
-.lot        00;38;5;8
-.out        00;38;5;8
-.toc        00;38;5;8
-.bbl        00;38;5;8
-.blg        00;38;5;8
-*~          00;38;5;8
-*#          00;38;5;8
-.part       00;38;5;8
-.incomplete 00;38;5;8
-.swp        00;38;5;8
-.tmp        00;38;5;8
-.temp       00;38;5;8
-.o          00;38;5;8
-.pyc        00;38;5;8
-.class      00;38;5;8
-.cache      00;38;5;8
-
-# Audio formats (orange)
-.aac    00;38;5;1
-.au     00;38;5;1
-.flac   00;38;5;1
-.mid    00;38;5;1
-.midi   00;38;5;1
-.mka    00;38;5;1
-.mp3    00;38;5;1
-.mpc    00;38;5;1
-.ogg    00;38;5;1
-.opus   00;38;5;1
-.ra     00;38;5;1
-.wav    00;38;5;1
-.m4a    00;38;5;1
-# http://wiki.xiph.org/index.php/MIME_Types_and_File_Extensions
-.axa    00;38;5;1
-.oga    00;38;5;1
-.spx    00;38;5;1
-.xspf   00;38;5;1
-
-# Video formats (as audio + bold)
-.mov    00;38;5;1
-.MOV    00;38;5;1
-.mpg    00;38;5;1
-.mpeg   00;38;5;1
-.m2v    00;38;5;1
-.mkv    00;38;5;1
-.ogm    00;38;5;1
-.mp4    00;38;5;1
-.m4v    00;38;5;1
-.mp4v   00;38;5;1
-.vob    00;38;5;1
-.qt     00;38;5;1
-.nuv    00;38;5;1
-.wmv    00;38;5;1
-.asf    00;38;5;1
-.rm     00;38;5;1
-.rmvb   00;38;5;1
-.flc    00;38;5;1
-.avi    00;38;5;1
-.fli    00;38;5;1
-.flv    00;38;5;1
-.gl     00;38;5;1
-.m2ts   00;38;5;1
-.divx   00;38;5;1
-.webm   00;38;5;1
-# http://wiki.xiph.org/index.php/MIME_Types_and_File_Extensions
-.axv 00;38;5;1
-.anx 00;38;5;1
-.ogv 00;38;5;1
-.ogx 00;38;5;1
+# NOTES:
+# - See http://www.oreilly.com/catalog/wdnut/excerpt/color_names.html
+# - Color combinations
+#   ANSI Color code       Solarized  Notes                Universal             SolDark              SolLight
+#   ~~~~~~~~~~~~~~~       ~~~~~~~~~  ~~~~~                ~~~~~~~~~             ~~~~~~~              ~~~~~~~~
+#   00    none                                            NORMAL, FILE          <SAME>               <SAME>
+#   30    black           base02
+#   01;30 bright black    base03     bg of SolDark
+#   31    red             red                             docs & mm src         <SAME>               <SAME>
+#   01;31 bright red      orange                          EXEC                  <SAME>               <SAME>
+#   32    green           green                           editable text         <SAME>               <SAME>
+#   01;32 bright green    base01                          unimportant text      <SAME>
+#   33    yellow          yellow     unclear in light bg  multimedia            <SAME>               <SAME>
+#   01;33 bright yellow   base00     fg of SolLight                             unimportant non-text
+#   34    blue            blue       unclear in dark bg   user customized       <SAME>               <SAME>
+#   01;34 bright blue     base0      fg in SolDark                                                   unimportant text
+#   35    magenta         magenta                         LINK                  <SAME>               <SAME>
+#   01;35 bright magenta  violet                          archive/compressed    <SAME>               <SAME>
+#   36    cyan            cyan                            DIR                   <SAME>               <SAME>
+#   01;36 bright cyan     base1                           unimportant non-text                       <SAME>
+#   37    white           base2
+#   01;37 bright white    base3      bg in SolLight
+#   05;37;41                         unclear in Putty dark
 
 
+### By file type
+
+# global default
+NORMAL 00
+# normal file
+FILE 00
+# directory
+DIR 36
+# symbolic link
+LINK 35
+
+# pipe, socket, block device, character device (blue bg)
+FIFO 30;44
+SOCK 35;44
+DOOR 35;44 # Solaris 2.5 and later
+BLK  33;44
+CHR  37;44
+
+
+#############################################################################
+### By file attributes
+
+# Orphaned symlinks (blinking white on red)
+# Blink may or may not work (works on iTerm dark or light, and Putty dark)
+ORPHAN  05;37;41
+# ... and the files that orphaned symlinks point to (blinking white on red)
+MISSING 05;37;41
+
+# files with execute permission
+EXEC 01;31  # Unix
+.cmd 01;31  # Win
+.exe 01;31  # Win
+.com 01;31  # Win
+.bat 01;31  # Win
+.reg 01;31  # Win
+.app 01;31  # OSX
+
+#############################################################################
+### By extension
+
+# List any file extensions like '.gz' or '.tar' that you would like ls
+# to colorize below. Put the extension, a space, and the color init string.
+# (and any comments you want to add after a '#')
+
+### Text formats
+
+# Text that we can edit with a regular editor
+.txt 32
+.org 32
+.md 32
+.mkd 32
+.bib 32
+
+# Source text
+.h 32
+.hpp 32
+.c 32
+.C 32
+.cc 32
+.cpp 32
+.cxx 32
+.objc 32
+.cl 32
+.sh 32
+.bash 32
+.csh 32
+.zsh 32
+.el 32
+.vim 32
+.java 32
+.pl 32
+.pm 32
+.py 32
+.rb 32
+.hs 32
+.php 32
+.htm 32
+.html 32
+.shtml 32
+.erb 32
+.haml 32
+.xml 32
+.rdf 32
+.css 32
+.sass 32
+.scss 32
+.less 32
+.js 32
+.coffee 32
+.man 32
+.0 32
+.1 32
+.2 32
+.3 32
+.4 32
+.5 32
+.6 32
+.7 32
+.8 32
+.9 32
+.l 32
+.n 32
+.p 32
+.pod 32
+.tex 32
+.go 32
+.sql 32
+.csv 32
+.sv 32
+.svh 32
+.v 32
+.vh 32
+.vhd 32
+
+### Multimedia formats
+
+# Image
+.bmp 33
+.cgm 33
+.dl 33
+.dvi 33
+.emf 33
+.eps 33
+.gif 33
+.jpeg 33
+.jpg 33
+.JPG 33
+.mng 33
+.pbm 33
+.pcx 33
+.pgm 33
+.png 33
+.PNG 33
+.ppm 33
+.pps 33
+.ppsx 33
+.ps 33
+.svg 33
+.svgz 33
+.tga 33
+.tif 33
+.tiff 33
+.xbm 33
+.xcf 33
+.xpm 33
+.xwd 33
+.xwd 33
+.yuv 33
+.NEF 33 # Nikon RAW format
+.nef 33
+.heic 33
+.HEIC 33
+
+# Audio
+.aac 33
+.au  33
+.flac 33
+.m4a 33
+.mid 33
+.midi 33
+.mka 33
+.mp3 33
+.mpa 33
+.mpeg 33
+.mpg 33
+.ogg  33
+.opus 33
+.ra 33
+.wav 33
+
+# Video
+.anx 33
+.asf 33
+.avi 33
+.axv 33
+.flc 33
+.fli 33
+.flv 33
+.gl 33
+.m2v 33
+.m4v 33
+.mkv 33
+.mov 33
+.MOV 33
+.mp4 33
+.mp4v 33
+.mpeg 33
+.mpg 33
+.nuv 33
+.ogm 33
+.ogv 33
+.ogx 33
+.qt 33
+.rm 33
+.rmvb 33
+.swf 33
+.vob 33
+.webm 33
+.wmv 33
+
+### Misc
+
+# Binary document formats and multimedia source
+.doc 31
+.docx 31
+.rtf 31
+.odt 31
+.dot 31
+.dotx 31
+.ott 31
+.xls 31
+.xlsx 31
+.ods 31
+.ots 31
+.ppt 31
+.pptx 31
+.odp 31
+.otp 31
+.fla 31
+.psd 31
+.pdf 31
+
+# Archives, compressed
+.7z   1;35
+.apk  1;35
+.arj  1;35
+.bin  1;35
+.bz   1;35
+.bz2  1;35
+.cab  1;35  # Win
+.deb  1;35
+.dmg  1;35  # OSX
+.gem  1;35
+.gz   1;35
+.iso  1;35
+.jar  1;35
+.msi  1;35  # Win
+.rar  1;35
+.rpm  1;35
+.tar  1;35
+.tbz  1;35
+.tbz2 1;35
+.tgz  1;35
+.tx   1;35
+.war  1;35
+.xpi  1;35
+.xz   1;35
+.z    1;35
+.Z    1;35
+.zip  1;35
+.zst  1;35
+
+# For testing
+.ANSI-30-black 30
+.ANSI-01;30-brblack 01;30
+.ANSI-31-red 31
+.ANSI-01;31-brred 01;31
+.ANSI-32-green 32
+.ANSI-01;32-brgreen 01;32
+.ANSI-33-yellow 33
+.ANSI-01;33-bryellow 01;33
+.ANSI-34-blue 34
+.ANSI-01;34-brblue 01;34
+.ANSI-35-magenta 35
+.ANSI-01;35-brmagenta 01;35
+.ANSI-36-cyan 36
+.ANSI-01;36-brcyan 01;36
+.ANSI-37-white 37
+.ANSI-01;37-brwhite 01;37
+
+#############################################################################
+# Your customizations
+
+# Unimportant text files
+# For universal scheme, use brightgreen 01;32
+# For optimal on light bg (but too prominent on dark bg), use white 01;34
+.log 01;32
+*~ 01;32
+*# 01;32
+#.log 01;34
+#*~ 01;34
+#*# 01;34
+
+# Unimportant non-text files
+# For universal scheme, use brightcyan 01;36
+# For optimal on dark bg (but too prominent on light bg), change to 01;33
+.bak 01;36
+.BAK 01;36
+.old 01;36
+.OLD 01;36
+.org_archive 01;36
+.off 01;36
+.OFF 01;36
+.dist 01;36
+.DIST 01;36
+.orig 01;36
+.ORIG 01;36
+.swp 01;36
+.swo 01;36
+*.v 01;36
+#.bak 01;33
+#.BAK 01;33
+#.old 01;33
+#.OLD 01;33
+#.org_archive 01;33
+#.off 01;33
+#.OFF 01;33
+#.dist 01;33
+#.DIST 01;33
+#.orig 01;33
+#.ORIG 01;33
+#.swp 01;33
+#.swo 01;33
+#*.v 01;33
+
+# The brightmagenta (Solarized: purple) color is free for you to use for your
+# custom file type
+.gpg 34
+.pgp 34
+.asc 34
+.3des 34
+.aes 34
+.enc 34
+.sqlite 34
+.db 34

--- a/.dircolors_tty
+++ b/.dircolors_tty
@@ -1,0 +1,750 @@
+#                                    LS_COLORS
+# Maintainers: Magnus Woldrich <m@japh.se>,
+#              Ryan Delaney <ryan.patrick.delaney@protonmail.com>
+#         URL: https://github.com/trapd00r/LS_COLORS
+#
+#   This is a collection of extension:color mappings, suitable to use as your
+#   LS_COLORS environment variable. Most of them use the extended color map,
+#   described in the ECMA-48 document; in other words, you'll need a terminal
+#   with capabilities of displaying 256 colors.
+#
+#   As of this writing, over 500 different filetypes/extensions are supported.
+#   That's indeed a lot of extensions, but there's a lot more! Therefore I need
+#   your help.
+#
+#   Fork this project on github, add the extensions you are missing, and send me
+#   a pull request.
+#
+#   For files that usually end up next to each other, like html, css and js,
+#   try to pick colors that fit nicely together. Filetypes with multiple
+#   possible extensions, like htm and html, should have the same color.
+
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the Perl Artistic License for more details.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the Perl Artistic License as published by the Perl Foundation,
+# either version 1.0 of the License, or (at your option) any later version.
+#
+# You should have received a copy of the Perl Artistic License along
+# with this program.  If not, see <http://www.perlfoundation.org/artistic_license_1_0>.
+
+# "NORMAL don't reset the bold attribute -
+# https://github.com/trapd00r/LS_COLORS/issues/11
+#NORMAL               38;5;254
+
+BLK                   38;5;68             # core
+CAPABILITY            38;5;17             # core
+CHR                   38;5;113;1          # core
+DIR                   38;5;30             # core
+DOOR                  38;5;127            # core
+EXEC                  38;5;208;1          # core
+FIFO                  38;5;126            # core
+FILE                  0                   # core
+LINK                  target              # core
+MULTIHARDLINK         38;5;222;1          # core
+NORMAL                0                   # core
+ORPHAN                48;5;196;38;5;232;1 # core
+OTHER_WRITABLE        38;5;220;1          # core
+SETGID                48;5;3;38;5;0       # core
+SETUID                38;5;220;1;3;100;1  # core
+SOCK                  38;5;197            # core
+STICKY                38;5;86;48;5;234    # core
+STICKY_OTHER_WRITABLE 48;5;235;38;5;139;3 # core
+*LS_COLORS 48;5;89;38;5;197;1;3;4;7       # :-)
+.txt                  38;5;253            # Plain-text
+*README               38;5;220;1          # Documentation
+*README.rst           38;5;220;1          # Documentation
+*README.md            38;5;220;1          # Documentation
+*LICENSE              38;5;220;1          # Documentation
+*LICENSE.md           38;5;220;1          # Documentation
+*COPYING              38;5;220;1          # Documentation
+*INSTALL              38;5;220;1          # Documentation
+*COPYRIGHT            38;5;220;1          # Documentation
+*AUTHORS              38;5;220;1          # Documentation
+*HISTORY              38;5;220;1          # Documentation
+*CONTRIBUTORS         38;5;220;1          # Documentation
+*CONTRIBUTING         38;5;220;1          # Documentation
+*CONTRIBUTING.md      38;5;220;1          # Documentation
+*CHANGELOG            38;5;220;1          # Documentation
+*CHANGELOG.md         38;5;220;1          # Documentation
+*CODEOWNERS           38;5;220;1          # Documentation
+*PATENTS              38;5;220;1          # Documentation
+*VERSION              38;5;220;1          # Documentation
+*NOTICE               38;5;220;1          # Documentation
+*CHANGES              38;5;220;1          # Documentation
+.log                  38;5;190            # Logs
+.adoc                 38;5;184            # Markup
+.asciidoc             38;5;184            # Markup
+.etx                  38;5;184            # Markup
+.info                 38;5;184            # Markup
+.markdown             38;5;184            # Markup
+.md                   38;5;184            # Markup
+.mkd                  38;5;184            # Markup
+.mdx                  38;5;184            # Markup
+.nfo                  38;5;184            # Markup
+.org                  38;5;184            # Markup
+.norg                 38;5;184            # Markup
+.pod                  38;5;184            # Markup
+.rst                  38;5;184            # Markup
+.tex                  38;5;184            # Markup
+.textile              38;5;184            # Markup
+.bib                  38;5;178            # Data store # non-relational
+.json                 38;5;178            # Data store # non-relational
+.jsonc                38;5;178            # Data store # non-relational
+.json5                38;5;178            # Data store # non-relational
+.hjson                38;5;178            # Data store # non-relational
+.jsonl                38;5;178            # Data store # non-relational
+.jsonnet              38;5;178            # Data store # non-relational
+.libsonnet            38;5;142            # Data store # non-relational
+.ndjson               38;5;178            # Data store # non-relational
+.msg                  38;5;178            # Data store # non-relational
+.pgn                  38;5;178            # Data store # non-relational
+.rss                  38;5;178            # Data store # non-relational
+.xml                  38;5;178            # Data store # non-relational
+.fxml                 38;5;178            # Data store # non-relational
+.toml                 38;5;178            # Data store # non-relational
+.yaml                 38;5;178            # Data store # non-relational
+.yml                  38;5;178            # Data store # non-relational
+.RData                38;5;178            # Data store # non-relational
+.rdata                38;5;178            # Data store # non-relational
+.xsd                  38;5;178            # Data store # non-relational
+.dtd                  38;5;178            # Data store # non-relational
+.sgml                 38;5;178            # Data store # non-relational
+.rng                  38;5;178            # Data store # non-relational
+.rnc                  38;5;178            # Data store # non-relational
+.accdb                38;5;60             # Data store # MS Access
+.accde                38;5;60             # Data store # MS Access
+.accdr                38;5;60             # Data store # MS Access
+.accdt                38;5;60             # Data store # MS Access
+.db                   38;5;60             # Data store
+.fmp12                38;5;60             # Data store
+.fp7                  38;5;60             # Data store
+.localstorage         38;5;60             # Data store
+.mdb                  38;5;60             # Data store
+.mde                  38;5;60             # Data store
+.sqlite               38;5;60             # Data store # SQLite
+.typelib              38;5;60             # Data store
+.nc                   38;5;60             # Data store # NetCDF
+.azw                  38;5;141            # Documents # binary
+.azw3                 38;5;141            # Documents # binary
+.cbr                  38;5;141            # Documents # binary
+.cbz                  38;5;141            # Documents # binary
+.chm                  38;5;141            # Documents # binary
+.djvu                 38;5;141            # Documents # binary
+.fb2                  38;5;141            # Documents # binary
+.pdf                  38;5;141            # Documents # binary
+.PDF                  38;5;141            # Documents # binary
+.mobi                 38;5;141            # Documents # binary
+.epub                 38;5;141            # Documents # binary
+.docm                 38;5;111;4          # Documents # with macros
+.doc                  38;5;111            # Documents
+.docx                 38;5;111            # Documents
+.odb                  38;5;111            # Documents
+.odt                  38;5;111            # Documents
+.rtf                  38;5;111            # Documents
+.pages                38;5;111            # Documents
+.odp                  38;5;166            # Presentation
+.pps                  38;5;166            # Presentation
+.ppt                  38;5;166            # Presentation
+.pptx                 38;5;166            # Presentation
+.ppts                 38;5;166            # Presentation
+.pptxm                38;5;166;4          # Presentation (with macros)
+.pptsm                38;5;166;4          # Presentation (with macros)
+.prisma               38;5;222            # Prisma Schema/Config
+.csv                  38;5;78             # Spreadsheet (plain text)
+.tsv                  38;5;78             # Spreadsheet (plain text)
+.numbers              38;5;112            # Spreadsheet
+.ods                  38;5;112            # Spreadsheet
+.xla                  38;5;76             # Spreadsheet
+.xls                  38;5;112            # Spreadsheet
+.xlsx                 38;5;112            # Spreadsheet
+.xlsxm                38;5;112;4          # Spreadsheet (with macros)
+.xltm                 38;5;73;4           # Spreadsheet (with macros)
+.xltx                 38;5;73             # Spreadsheet (with macros)
+.key                  38;5;166            # License keys
+*config               1                   # Configs
+*cfg                  1                   # Configs
+*conf                 1                   # Configs
+*rc                   1                   # Configs
+*authorized_keys      1                   # Configs
+*known_hosts          1                   # Configs
+.ini                  1                   # Configs
+.plist                1                   # Configs
+.profile              1                   # Configs
+.bash_profile         1                   # Configs
+.bash_login           1                   # Configs
+.bash_logout          1                   # Configs
+.zshenv               1                   # Configs
+.zprofile             1                   # Configs
+.zlogin               1                   # Configs
+.zlogout              1                   # Configs
+.viminfo              1                   # Configs
+.pcf                  1                   # Configs
+.psf                  1                   # Configs
+.hidden-color-scheme  1                   # Configs
+.hidden-tmTheme       1                   # Configs
+.last-run             1                   # Configs
+.merged-ca-bundle     1                   # Configs
+.sublime-build        1                   # Configs
+.sublime-commands     1                   # Configs
+.sublime-keymap       1                   # Configs
+.sublime-settings     1                   # Configs
+.sublime-snippet      1                   # Configs
+.sublime-project      1                   # Configs
+.sublime-workspace    1                   # Configs
+.tmTheme              1                   # Configs
+.user-ca-bundle       1                   # Configs
+.rstheme              1                   # Configs
+.epf                  1                   # Configs
+.git                  38;5;197            # Version control
+.github               38;5;197            # Version control
+.gitignore            38;5;240            # Version control
+.gitattributes        38;5;240            # Version control
+.gitmodules           38;5;240            # Version control
+.awk                  38;5;172            # Code (shell)
+.bash                 38;5;172            # Code (shell)
+.bat                  38;5;172            # Code (shell)
+.BAT                  38;5;172            # Code (shell)
+.sed                  38;5;172            # Code (shell)
+.sh                   38;5;172            # Code (shell)
+.zsh                  38;5;172            # Code (shell)
+.fish                 38;5;172            # Code (shell)
+.vim                  38;5;172            # Code (shell)
+.kak                  38;5;172            # Code (shell)
+.ahk                  38;5;41             # Code (interpreted) (AutoHotKey)
+.py                   38;5;41             # Code (interpreted) (Python)
+.ipynb                38;5;41             # Code (interpreted) (Python)
+.xsh                  38;5;41             # Code (interpreted) (xonsh)
+.rb                   38;5;41             # Code (interpreted) (ruby)
+.gemspec              38;5;41             # Code (interpreted) (ruby)
+.pl                   38;5;208            # Code (interpreted) (Perl)
+.PL                   38;5;160            # Code (interpreted) (Perl)
+.pm                   38;5;203            # Code (interpreted) (Perl)
+.t                    38;5;114            # Code (interpreted) (Perl)
+.msql                 38;5;222            # Code (SQL)
+.mysql                38;5;222            # Code (SQL)
+.prql                 38;5;222            # Code (SQL)
+.pgsql                38;5;222            # Code (SQL)
+.sql                  38;5;222            # Code (SQL)
+.tcl                  38;5;64;1           # Code (interpreted) (Tool Command Language)
+.r                    38;5;49             # Code (interpreted) (R)
+.R                    38;5;49             # Code (interpreted) (R)
+.gs                   38;5;81             # GrADS
+.clj                  38;5;41             # Clojure
+.cljs                 38;5;41             # Clojure
+.cljc                 38;5;41             # Clojure
+.cljw                 38;5;41             # Clojure Gorilla notebook
+.scala                38;5;41             # Scala
+.sc                   38;5;41             # Scala
+.dart                 38;5;51             # Dart
+.asm                  38;5;81             # ASM
+.cl                   38;5;81             # LISP
+.ml                   38;5;81             # LISP
+.lisp                 38;5;81             # LISP
+.rkt                  38;5;81             # LISP
+.el                   38;5;81             # LISP (Emacs)
+.elc                  38;5;241            # LISP (Emacs)
+.eln                  38;5;241            # LISP (Emacs)
+.lua                  38;5;81             # Code (interpreted) (Lua)
+.moon                 38;5;81             # Code (interpreted) (Moonscript)
+.c                    38;5;81             # C
+.C                    38;5;81             # C
+.h                    38;5;110            # C headers
+.H                    38;5;110            # C headers
+.tcc                  38;5;110            # C headers
+.c++                  38;5;81             # C++
+.h++                  38;5;110            # C++ headers
+.hpp                  38;5;110            # C++ headers
+.hxx                  38;5;110            # C++ headers
+.ii                   38;5;110            # C++ headers
+.M                    38;5;110            # Objective C method file
+.m                    38;5;110            # Objective C method file
+.cc                   38;5;81             # Csharp
+.cs                   38;5;81             # Csharp
+.cp                   38;5;81             # Csharp
+.cpp                  38;5;81             # Csharp
+.cxx                  38;5;81             # Csharp
+.cr                   38;5;81             # Crystal
+.go                   38;5;81             # Golang
+.f                    38;5;81             # Fortran
+.F                    38;5;81             # Fortran
+.for                  38;5;81             # Fortran
+.ftn                  38;5;81             # Fortran
+.f90                  38;5;81             # Fortran
+.F90                  38;5;81             # Fortran
+.f95                  38;5;81             # Fortran
+.F95                  38;5;81             # Fortran
+.f03                  38;5;81             # Fortran
+.F03                  38;5;81             # Fortran
+.f08                  38;5;81             # Fortran
+.F08                  38;5;81             # Fortran
+.nim                  38;5;81             # Nim
+.nimble               38;5;81             # Nim
+.s                    38;5;110            # Pascal
+.S                    38;5;110            # Pascal
+.rs                   38;5;81             # Code (compiled) (Rust)
+.scpt                 38;5;219            # AppleScript
+.swift                38;5;219            # Swift
+.sx                   38;5;81             # SimplexNumerica
+.vala                 38;5;81             # Vala
+.vapi                 38;5;81             # Vala
+.hi                   38;5;110            # Haskell
+.hs                   38;5;81             # Haskell
+.lhs                  38;5;81             # Haskell
+.agda                 38;5;81             # Agda
+.lagda                38;5;81             # Agda
+.lagda.tex            38;5;81             # Agda
+.lagda.rst            38;5;81             # Agda
+.lagda.md             38;5;81             # Agda
+.agdai                38;5;110            # Agda
+.zig                  38;5;81             # Zig
+.v                    38;5;81             # V
+.rego                 38;5;178            # Code (Rego)
+.pyc                  38;5;240            # Code (Python)
+.tf                   38;5;168            # Code (Terraform)
+.tfstate              38;5;168            # Code (Terraform)
+.tfvars               38;5;168            # Code (Terraform)
+.http                 38;5;90;1           # Request (Web)
+.eml                  38;5;90;1           # Email (Web)
+.css                  38;5;105;1          # Styling (Web)
+.less                 38;5;105;1          # Styling (Web)
+.sass                 38;5;105;1          # Styling (Web)
+.scss                 38;5;105;1          # Styling (Web)
+.htm                  38;5;125;1          # Styling (Web)
+.html                 38;5;125;1          # Markup (Web)
+.jhtm                 38;5;125;1          # Markup (Web)
+.mht                  38;5;125;1          # Markup (Web)
+.mustache             38;5;135;1          # Templating (Web)
+.ejs                  38;5;135;1          # Templating (Web)
+.pug                  38;5;135;1          # Templating (Web)
+.svelte               38;5;135;1          # Templating (Web)
+.vue                  38;5;135;1          # Templating (Web)
+.astro                38;5;135;1          # Templating (Web)
+.js                   38;5;074;1          # Javascript
+.jsx                  38;5;074;1          # Javascript eXtended
+.ts                   38;5;074;1          # Typescript
+.tsx                  38;5;074;1          # Typescript eXtended
+.mjs                  38;5;074;1          # ECMAScript
+.cjs                  38;5;074;1          # CommonJS
+.coffee               38;5;079;1          # Java
+.java                 38;5;079;1          # Java
+.jsm                  38;5;079;1          # Java
+.jsp                  38;5;079;1          # Java
+.php                  38;5;81             # php
+.ctp                  38;5;81             # php (CakePHP)
+.twig                 38;5;81             # php (Twig)
+.vb                   38;5;81             # VBA
+.vba                  38;5;81             # VBA
+.vbs                  38;5;81             # VBA
+*Containerfile        38;5;155            # Build process # Containers
+.containerignore      38;5;240            # Build process # Containers
+*Dockerfile           38;5;155            # Build process (Docker)
+.dockerignore         38;5;240            # Build process (Docker)
+*Makefile             38;5;155            # Build process (Make)
+*MANIFEST             38;5;243            # Build process (Make)
+*pm_to_blib           38;5;240            # Build process (Perl)
+.nix                  38;5;155            # Functional configuration
+.dhall                38;5;178            # Functional configuration
+.rake                 38;5;155            # Build process (Ruby)
+.am                   38;5;242            # Build process (Automake)
+.in                   38;5;242            # Build process (Automake)
+.hin                  38;5;242            # Build process (Automake)
+.scan                 38;5;242            # Build process (Automake)
+.m4                   38;5;242            # Build process (Automake)
+.old                  38;5;242            # Build process (Automake)
+.out                  38;5;242            # Build process (Automake)
+.SKIP                 38;5;244            # Build process (Automake)
+.diff                 48;5;197;38;5;232   # Patch files
+.patch                48;5;197;38;5;232;1 # Patch files
+.bmp                  38;5;97             # Graphics
+.dicom                38;5;97             # Graphics
+.tiff                 38;5;97             # Graphics
+.tif                  38;5;97             # Graphics
+.TIFF                 38;5;97             # Graphics
+.cdr                  38;5;97             # Graphics
+.flif                 38;5;97             # Graphics
+.gif                  38;5;97             # Graphics
+.icns                 38;5;97             # Graphics
+.ico                  38;5;97             # Graphics
+.jpeg                 38;5;97             # Graphics
+.JPG                  38;5;97             # Graphics
+.jpg                  38;5;97             # Graphics
+.jxl                  38;5;97             # Graphics
+.nth                  38;5;97             # Graphics
+.png                  38;5;97             # Graphics
+.psd                  38;5;97             # Graphics
+.pxd                  38;5;97             # Graphics
+.pxm                  38;5;97             # Graphics
+.xpm                  38;5;97             # Graphics
+.webp                 38;5;97             # Graphics
+.ai                   38;5;99             # Graphics (Vector)
+.eps                  38;5;99             # Graphics (Vector)
+.epsf                 38;5;99             # Graphics (Vector)
+.drw                  38;5;99             # Graphics (Vector)
+.ps                   38;5;99             # Graphics (Vector)
+.svg                  38;5;99             # Graphics (Vector)
+.avi                  38;5;114            # Video
+.divx                 38;5;114            # Video
+.IFO                  38;5;114            # Video
+.m2v                  38;5;114            # Video
+.m4v                  38;5;114            # Video
+.mkv                  38;5;114            # Video
+.MOV                  38;5;114            # Video
+.mov                  38;5;114            # Video
+.mp4                  38;5;114            # Video
+.mpeg                 38;5;114            # Video
+.mpg                  38;5;114            # Video
+.ogm                  38;5;114            # Video
+.rmvb                 38;5;114            # Video
+.sample               38;5;114            # Video
+.wmv                  38;5;114            # Video
+.3g2                  38;5;115            # Video (mobile/streaming)
+.3gp                  38;5;115            # Video (mobile/streaming)
+.gp3                  38;5;115            # Video (mobile/streaming)
+.webm                 38;5;115            # Video (mobile/streaming)
+.gp4                  38;5;115            # Video (mobile/streaming)
+.asf                  38;5;115            # Video (mobile/streaming)
+.flv                  38;5;115            # Video (mobile/streaming)
+.ogv                  38;5;115            # Video (mobile/streaming)
+.f4v                  38;5;115            # Video (mobile/streaming)
+.VOB                  38;5;115;1          # Video (lossless)
+.vob                  38;5;115;1          # Video (lossless)
+.ass                  38;5;117            # Subtitles
+.srt                  38;5;117            # Subtitles
+.ssa                  38;5;117            # Subtitles
+.sub                  38;5;117            # Subtitles
+.sup                  38;5;117            # Subtitles
+.vtt                  38;5;117            # Subtitles
+.3ga                  38;5;137;1          # Audio (lossy)
+.S3M                  38;5;137;1          # Audio (lossy)
+.aac                  38;5;137;1          # Audio (lossy)
+.amr                  38;5;137;1          # Audio (lossy)
+.au                   38;5;137;1          # Audio (lossy)
+.caf                  38;5;137;1          # Audio (lossy)
+.dat                  38;5;137;1          # Audio (lossy)
+.dts                  38;5;137;1          # Audio (lossy)
+.fcm                  38;5;137;1          # Audio (lossy)
+.m4a                  38;5;137;1          # Audio (lossy)
+.mod                  38;5;137;1          # Audio (lossy)
+.mp3                  38;5;137;1          # Audio (lossy)
+.mp4a                 38;5;137;1          # Audio (lossy)
+.oga                  38;5;137;1          # Audio (lossy)
+.ogg                  38;5;137;1          # Audio (lossy)
+.opus                 38;5;137;1          # Audio (lossy)
+.s3m                  38;5;137;1          # Audio (lossy)
+.sid                  38;5;137;1          # Audio (lossy)
+.wma                  38;5;137;1          # Audio (lossy)
+.ape                  38;5;136;1          # Audio (lossless)
+.aiff                 38;5;136;1          # Audio (lossless)
+.cda                  38;5;136;1          # Audio (lossless)
+.flac                 38;5;136;1          # Audio (lossless)
+.alac                 38;5;136;1          # Audio (lossless)
+.mid                  38;5;136;1          # Audio (lossless)
+.midi                 38;5;136;1          # Audio (lossless)
+.pcm                  38;5;136;1          # Audio (lossless)
+.wav                  38;5;136;1          # Audio (lossless)
+.wv                   38;5;136;1          # Audio (lossless)
+.wvc                  38;5;136;1          # Audio (lossless)
+.afm                  38;5;66             # Fonts
+.fon                  38;5;66             # Fonts
+.fnt                  38;5;66             # Fonts
+.pfb                  38;5;66             # Fonts
+.pfm                  38;5;66             # Fonts
+.ttf                  38;5;66             # Fonts
+.otf                  38;5;66             # Fonts
+.woff                 38;5;66             # Fonts
+.woff2                38;5;66             # Fonts
+.PFA                  38;5;66             # Fonts
+.pfa                  38;5;66             # Fonts
+*.7z                  38;5;40             # Archives
+*.a                   38;5;40             # Archives
+*.arj                 38;5;40             # Archives
+*.br                  38;5;40             # Archives
+*.bz2                 38;5;40             # Archives
+*.cpio                38;5;40             # Archives
+*.gz                  38;5;40             # Archives
+*.lrz                 38;5;40             # Archives
+*.lz                  38;5;40             # Archives
+*.lzma                38;5;40             # Archives
+*.lzo                 38;5;40             # Archives
+*.rar                 38;5;40             # Archives
+*.s7z                 38;5;40             # Archives
+*.sz                  38;5;40             # Archives
+*.tar                 38;5;40             # Archives
+*.tbz                 38;5;40             # Archives
+*.tgz                 38;5;40             # Archives
+*.warc                38;5;40             # Archives
+*.WARC                38;5;40             # Archives
+*.xz                  38;5;40             # Archives
+*.z                   38;5;40             # Archives
+*.zip                 38;5;40             # Archives
+*.zipx                38;5;40             # Archives
+*.zoo                 38;5;40             # Archives
+*.zpaq                38;5;40             # Archives
+*.zst                 38;5;40             # Archives
+*.zstd                38;5;40             # Archives
+*.zz                  38;5;40             # Archives
+.apk                  38;5;215            # Packaged apps
+.ipa                  38;5;215            # Packaged apps
+.deb                  38;5;215            # Packaged apps
+.rpm                  38;5;215            # Packaged apps
+.jad                  38;5;215            # Packaged apps
+.jar                  38;5;215            # Packaged apps
+.ear                  38;5;215            # Packaged apps
+.war                  38;5;215            # Packaged apps
+.cab                  38;5;215            # Packaged apps
+.pak                  38;5;215            # Packaged apps
+.pk3                  38;5;215            # Packaged apps
+.vdf                  38;5;215            # Packaged apps
+.vpk                  38;5;215            # Packaged apps
+.bsp                  38;5;215            # Packaged apps
+.dmg                  38;5;215            # Packaged apps
+.crx                  38;5;215            # Packaged apps # Google Chrome extension
+.xpi                  38;5;215            # Packaged apps # Mozilla Firefox extension
+.iso                  38;5;124            # Partition images
+.img                  38;5;124            # Partition images
+.bin                  38;5;124            # Partition images
+.nrg                  38;5;124            # Partition images
+.qcow                 38;5;124            # Partition images
+.fvd                  38;5;124            # Partition images
+.sparseimage          38;5;124            # Partition images
+.toast                38;5;124            # Partition images
+.vcd                  38;5;124            # Partition images
+.vdi                  38;5;124            # Partition images
+.vhd                  38;5;124            # Partition images
+.vhdx                 38;5;124            # Partition images
+.vfd                  38;5;124            # Partition images
+.vmdk                 38;5;124            # Partition images
+.swp                  38;5;244            # Temporary files
+.swo                  38;5;244            # Temporary files
+.tmp                  38;5;244            # Temporary files
+.sassc                38;5;244            # Temporary files
+.pacnew               38;5;33             # Undo files
+.un~                  38;5;241            # Undo files
+.orig                 38;5;241            # Undo files
+.BUP                  38;5;241            # Backups
+.bak                  38;5;241            # Backups
+.o                    38;5;241            # *nix Object file (shared libraries, core dumps etc)
+*core                 38;5;241            # Linux user core dump file (from /proc/sys/kernel/core_pattern)
+.mdump                38;5;241            # Mini DuMP crash report
+.rlib                 38;5;241            # Static rust library
+.dll                  38;5;241            # dynamic linked library
+.aria2                38;5;241            # state dumps
+.dump                 38;5;241            # state dumps
+.stackdump            38;5;241            # state dumps
+.zcompdump            38;5;241            # state dumps
+.zwc                  38;5;241            # state dumps
+.part                 38;5;239            # Partial files
+.r[0-9]{0,2}          38;5;239            # Archive segments
+.zx[0-9]{0,2}         38;5;239            # Archive segments
+.z[0-9]{0,2}          38;5;239            # Archive segments
+.pid                  38;5;248            # state files
+.state                38;5;248            # state files
+*lockfile             38;5;248            # state files
+*lock                 38;5;248            # state files
+.err                  38;5;160;1          # error logs
+.error                38;5;160;1          # error logs
+.stderr               38;5;160;1          # error logs
+.pcap                 38;5;29             # tcpdump / network traffic capture
+.cap                  38;5;29             # tcpdump / network traffic capture
+.dmp                  38;5;29             # tcpdump / network traffic capture
+.allow                38;5;112            # /etc/hosts
+.deny                 38;5;196            # /etc/hosts
+.service              38;5;45             # systemd
+*@.service            38;5;45             # systemd
+.socket               38;5;45             # systemd
+.swap                 38;5;45             # systemd
+.device               38;5;45             # systemd
+.mount                38;5;45             # systemd
+.automount            38;5;45             # systemd
+.target               38;5;45             # systemd
+.path                 38;5;45             # systemd
+.timer                38;5;45             # systemd
+.snapshot             38;5;45             # systemd
+.lnk                  38;5;39             # windows symlink
+.application          38;5;116            # metadata
+.cue                  38;5;116            # metadata
+.description          38;5;116            # metadata
+.directory            38;5;116            # metadata
+.m3u                  38;5;116            # metadata
+.m3u8                 38;5;116            # metadata
+.md5                  38;5;116            # metadata
+.properties           38;5;116            # metadata
+.sfv                  38;5;116            # metadata
+.theme                38;5;116            # metadata
+.torrent              38;5;116            # metadata
+.urlview              38;5;116            # metadata
+.webloc               38;5;116            # metadata
+.asc                  38;5;192;3          # Encrypted data
+.bfe                  38;5;192;3          # Encrypted data
+.enc                  38;5;192;3          # Encrypted data
+.gpg                  38;5;192;3          # Encrypted data
+.signature            38;5;192;3          # Encrypted data
+.sig                  38;5;192;3          # Encrypted data
+.p12                  38;5;192;3          # Encrypted data
+.pem                  38;5;192;3          # Encrypted data
+.pgp                  38;5;192;3          # Encrypted data
+.p7s                  38;5;192;3          # Encrypted data
+*id_dsa               38;5;192;3          # Encrypted data
+*id_rsa               38;5;192;3          # Encrypted data
+*id_ecdsa             38;5;192;3          # Encrypted data
+*id_ed25519           38;5;192;3          # Encrypted data
+.32x                  38;5;213            # Game console emulation
+.cdi                  38;5;213            # Game console emulation
+.fm2                  38;5;213            # Game console emulation
+.rom                  38;5;213            # Game console emulation
+.sav                  38;5;213            # Game console emulation
+.st                   38;5;213            # Game console emulation
+.a00                  38;5;213            # Game console emulation # Atari
+.a52                  38;5;213            # Game console emulation # Atari
+.A64                  38;5;213            # Game console emulation # Atari
+.a64                  38;5;213            # Game console emulation # Atari
+.a78                  38;5;213            # Game console emulation # Atari
+.adf                  38;5;213            # Game console emulation # Atari
+.atr                  38;5;213            # Game console emulation # Atari
+.gb                   38;5;213            # Game console emulation # Nintendo
+.gba                  38;5;213            # Game console emulation # Nintendo
+.gbc                  38;5;213            # Game console emulation # Nintendo
+.gel                  38;5;213            # Game console emulation # Nintendo
+.gg                   38;5;213            # Game console emulation # Nintendo
+.ggl                  38;5;213            # Game console emulation # Nintendo
+.ipk                  38;5;213            # Game console emulation # Nintendo DS Packed Images
+.j64                  38;5;213            # Game console emulation # Nintendo
+.nds                  38;5;213            # Game console emulation # Nintendo
+.nes                  38;5;213            # Game console emulation # Nintendo NES
+.sms                  38;5;213            # Sega
+.8xp                  38;5;121            # Texas Instruments Calculator files
+.8eu                  38;5;121            # Texas Instruments Calculator files
+.82p                  38;5;121            # Texas Instruments Calculator files
+.83p                  38;5;121            # Texas Instruments Calculator files
+.8xe                  38;5;121            # Texas Instruments Calculator files
+.stl                  38;5;216            # 3D printing
+.dwg                  38;5;216            # 3D printing
+.ply                  38;5;216            # 3D printing
+.wrl                  38;5;216            # 3D printing
+.vert                 38;5;136            # SPIR-V shaders
+.comp                 38;5;136            # SPIR-V shaders
+.frag                 38;5;136            # SPIR-V shaders
+.spv                  38;5;217            # SPIR-V compiled shaders
+.wgsl                 38;5;97             # WGSL shaders
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# unknown / weirdos
+.xib                  38;5;208
+.iml                  38;5;166            # AppCode files
+
+.DS_Store             38;5;239            # macOS
+.localized            38;5;239            # macOS
+.CFUserTextEncoding   38;5;239            # macOS
+*CodeResources        38;5;239            # macOS code signing apps
+*PkgInfo              38;5;239            # macOS app bundle id
+.nib                  38;5;57             # macOS UI
+.car                  38;5;57             # macOS asset catalog
+.dylib                38;5;241            # macOS shared lib
+.entitlements         1                   # Xcode files
+.pbxproj              1                   # Xcode files
+.strings              1                   # Xcode files
+.storyboard           38;5;196            # Xcode files
+.xcconfig             1                   # Xcode files
+.xcsettings           1                   # Xcode files
+.xcuserstate          1                   # Xcode files
+.xcworkspacedata      1                   # Xcode files
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# unsorted
+.pot                  38;5;7
+.pcb                  38;5;7
+.mm                   38;5;7
+.gbr                  38;5;7
+.scm                  38;5;7
+.xcf                  38;5;7
+.spl                  38;5;7
+.Rproj                38;5;11
+.sis                  38;5;7
+.1p                   38;5;7
+.3p                   38;5;7
+.cnc                  38;5;7
+.def                  38;5;7
+.ex                   38;5;7
+.example              38;5;7
+.feature              38;5;7
+.ger                  38;5;7
+.ics                  38;5;7              # calendar information
+.map                  38;5;7
+.mf                   38;5;7
+.mfasl                38;5;7
+.mi                   38;5;7
+.mtx                  38;5;7
+.pc                   38;5;7
+.pi                   38;5;7
+.plt                  38;5;7
+.rdf                  38;5;7
+.ru                   38;5;7
+.sch                  38;5;7
+.sty                  38;5;7
+.sug                  38;5;7
+.tdy                  38;5;7
+.tfm                  38;5;7
+.tfnt                 38;5;7
+.tg                   38;5;7
+.vcard                38;5;7              # contact information
+.vcf                  38;5;7              # contact information
+.xln                  38;5;7
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# termcap
+TERM ansi
+TERM color-xterm
+TERM con132x25
+TERM con132x30
+TERM con132x43
+TERM con132x60
+TERM con80x25
+TERM con80x28
+TERM con80x30
+TERM con80x43
+TERM con80x50
+TERM con80x60
+TERM cons25
+TERM console
+TERM cygwin
+TERM dtterm
+TERM Eterm
+TERM eterm-color
+TERM gnome
+TERM gnome-256color
+TERM jfbterm
+TERM konsole
+TERM kterm
+TERM linux
+TERM linux-c
+TERM mach-color
+TERM mlterm
+TERM putty
+TERM rxvt
+TERM rxvt-256color
+TERM rxvt-cygwin
+TERM rxvt-cygwin-native
+TERM rxvt-unicode
+TERM rxvt-unicode-256color
+TERM rxvt-unicode256
+TERM screen
+TERM screen-256color
+TERM screen-256color-bce
+TERM screen-bce
+TERM screen-w
+TERM screen.linux
+TERM screen.rxvt
+TERM terminator
+TERM tmux-256color
+TERM vt100
+TERM xterm
+TERM xterm-16color
+TERM xterm-256color
+TERM xterm-88color
+TERM xterm-color
+TERM xterm-debian
+TERM xterm-kitty
+TERM wezterm

--- a/.local/bin/codex-notify
+++ b/.local/bin/codex-notify
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+sound="/usr/share/sounds/freedesktop/stereo/complete.oga"
+
+if command -v pw-play >/dev/null 2>&1 && [[ -f "$sound" ]]; then
+    pw-play "$sound" >/dev/null 2>&1
+elif command -v paplay >/dev/null 2>&1 && [[ -f "$sound" ]]; then
+    paplay "$sound" >/dev/null 2>&1
+else
+    printf '\a' >/dev/tty
+fi


### PR DESCRIPTION
## Summary

- update `.bashrc`, `.bash_aliases`, and `.dircolors` from the maintained private dotfiles source
- add a dedicated Linux-console `.dircolors_tty`
- add the Codex completion notification helper

## Why

The public repository had not been synchronized with the maintained shell configuration since 2024. The update carries over safer interactive startup behavior, idempotent PATH and prompt-hook handling, robust optional-tool checks, updated color mappings, and the completion notification helper while intentionally excluding machine-specific and private configuration.

## Impact

Users get the current Bash setup and color configuration. Optional integrations remain guarded, repeated `.bashrc` sourcing stays stable, and Codex can play a completion sound when configured to call the included helper.

## Privacy scope

This PR intentionally excludes `.codex/config.toml`, `.xprofile`, `.gitmodules`, private scripts, desktop entries, and broken configuration symlinks.

## Validation

- `bash -n` on `.bashrc`, `.bash_aliases`, and `.local/bin/codex-notify`
- ShellCheck on all three shell files
- `dircolors -b` on `.dircolors` and `.dircolors_tty`
- sensitive-pattern scan of the published files
- `git diff --check`
