### PR TITLE
Add assets branch maintenance guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# README assets
+
+This orphan branch stores only the images referenced by `README.md` on the
+`master` branch. Keeping these files in a separate history prevents regular
+clones of the dotfiles from downloading presentation-only assets.
+
+Do not merge this branch into `master`.
+
+To update an image, create a branch from `assets` and open a pull request whose
+base branch is `assets`. Images can be referenced from the main README with:
+
+```text
+https://raw.githubusercontent.com/thomastuul/Dotfiles/assets/<filename>
+```


### PR DESCRIPTION
## Summary

- add branch-local documentation for the orphan `assets` branch
- explain why the branch is separate from `master`
- document the expected PR target and raw GitHub URL format for image updates
- explicitly warn against merging `assets` into `master`

## Impact

Anyone checking out the assets history can immediately identify its purpose and update images without mixing the branch into the dotfiles history.

## Validation

- `git diff --check`
